### PR TITLE
FIX: #1024 - Overflow do dashboard de admin em telas com aspect ratio 16:10

### DIFF
--- a/frontend/app/components/ui/table.tsx
+++ b/frontend/app/components/ui/table.tsx
@@ -10,7 +10,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
     >
       <table
         data-slot="table"
-        className={cn("w-full caption-bottom text-sm", className)}
+        className={cn("w-full caption-bottom text-xs lg:text-sm", className)}
         {...props}
       />
     </div>


### PR DESCRIPTION
Alterado tamanho da fonte dos titulos das colunas do data table para telas menores.