### PR TITLE
Ajustes no ms-cliente para ficar de acordo com as especificações

### DIFF
--- a/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/application/dto/request/AlterarPerfilRequest.java
+++ b/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/application/dto/request/AlterarPerfilRequest.java
@@ -1,0 +1,48 @@
+package com.ufpr.bantads.cliente.application.dto.request;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.util.Locale;
+
+public record AlterarPerfilRequest(
+
+    @NotBlank(message = "Nome é obrigatório")
+    String nome,
+
+    @NotBlank(message = "Email é obrigatório")
+    @Email(message = "Email inválido")
+    String email,
+
+    @NotBlank(message = "Telefone é obrigatório")
+    String telefone,
+
+    @NotNull(message = "Salário é obrigatório")
+    @DecimalMin(value = "0.01", message = "Salário deve ser maior que zero")
+    BigDecimal salario,
+
+    @NotBlank(message = "CEP é obrigatório")
+    String cep,
+
+    @NotBlank(message = "Logradouro é obrigatório")
+    String logradouro,
+
+    @NotBlank(message = "Cidade é obrigatória")
+    String cidade,
+
+    @NotBlank(message = "Estado é obrigatório")
+    @Size(min = 2, max = 2, message = "Estado deve ter 2 caracteres, por exemplo: PR")
+    String estado,
+
+    String complemento,
+
+    @NotBlank(message = "Número é obrigatório")
+    String numero
+) {
+    public AlterarPerfilRequest {
+        estado = estado == null ? null : estado.trim().toUpperCase(Locale.ROOT);
+    }
+}

--- a/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/application/usecase/AlterarPerfilUseCase.java
+++ b/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/application/usecase/AlterarPerfilUseCase.java
@@ -1,0 +1,45 @@
+package com.ufpr.bantads.cliente.application.usecase;
+
+import org.springframework.stereotype.Service;
+
+import com.ufpr.bantads.cliente.application.dto.request.AlterarPerfilRequest;
+import com.ufpr.bantads.cliente.application.dto.response.ClienteResponse;
+import com.ufpr.bantads.cliente.domain.exception.ClienteNaoEncontradoException;
+import com.ufpr.bantads.cliente.domain.model.Cliente;
+import com.ufpr.bantads.cliente.domain.model.StatusCliente;
+import com.ufpr.bantads.cliente.domain.repository.ClienteRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AlterarPerfilUseCase {
+
+    private final ClienteRepository clienteRepository;
+
+    public ClienteResponse execute(String cpf, AlterarPerfilRequest request) {
+        Cliente cliente = clienteRepository.findByCpf(cpf)
+            .orElseThrow(() -> new ClienteNaoEncontradoException(cpf));
+
+        if (cliente.getStatus() == StatusCliente.REJEITADO) {
+            throw new ClienteNaoEncontradoException(cpf);
+        }
+
+        cliente.setNome(request.nome());
+        cliente.setEmail(request.email());
+        cliente.setTelefone(request.telefone());
+        cliente.setSalario(request.salario());
+
+        var endereco = cliente.getEndereco();
+        endereco.setCep(request.cep());
+        endereco.setLogradouro(request.logradouro());
+        endereco.setNumero(request.numero());
+        endereco.setComplemento(request.complemento());
+        endereco.setCidade(request.cidade());
+        endereco.setEstado(request.estado());
+
+        Cliente atualizado = clienteRepository.save(cliente);
+
+        return ClienteResponse.fromEntity(atualizado);
+    }
+}

--- a/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/application/usecase/GetClienteByCpfUseCase.java
+++ b/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/application/usecase/GetClienteByCpfUseCase.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import com.ufpr.bantads.cliente.application.dto.response.ClienteResponse;
 import com.ufpr.bantads.cliente.domain.exception.ClienteNaoEncontradoException;
+import com.ufpr.bantads.cliente.domain.model.StatusCliente;
 import com.ufpr.bantads.cliente.domain.repository.ClienteRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,10 @@ public class GetClienteByCpfUseCase {
     public ClienteResponse execute(String cpf) {
         var cliente = clienteRepository.findByCpf(cpf)
             .orElseThrow(() -> new ClienteNaoEncontradoException(cpf));
+
+        if (cliente.getStatus() == StatusCliente.REJEITADO) {
+            throw new ClienteNaoEncontradoException(cpf);
+        }
 
         return ClienteResponse.fromEntity(cliente);
     }

--- a/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/application/usecase/ListAllClientesUseCase.java
+++ b/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/application/usecase/ListAllClientesUseCase.java
@@ -17,7 +17,7 @@ public class ListAllClientesUseCase {
     private final ClienteRepository clienteRepository;
 
     public List<ClienteResponse> execute() {
-        return clienteRepository.findByStatus(StatusCliente.APROVADO)
+        return clienteRepository.findByStatusOrderByNomeAsc(StatusCliente.APROVADO)
             .stream()
             .map(ClienteResponse::fromEntity)
             .toList();

--- a/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/application/usecase/ListClientesParaAprovarUseCase.java
+++ b/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/application/usecase/ListClientesParaAprovarUseCase.java
@@ -17,7 +17,7 @@ public class ListClientesParaAprovarUseCase {
     private final ClienteRepository clienteRepository;
 
     public List<ClienteParaAprovarResponse> execute() {
-        return clienteRepository.findByStatus(StatusCliente.PENDENTE)
+        return clienteRepository.findByStatusOrderByCreatedAtAsc(StatusCliente.PENDENTE)
             .stream()
             .map(ClienteParaAprovarResponse::fromEntity)
             .toList();

--- a/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/domain/repository/ClienteRepository.java
+++ b/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/domain/repository/ClienteRepository.java
@@ -16,6 +16,10 @@ public interface ClienteRepository extends JpaRepository<Cliente, Long> {
 
     List<Cliente> findByStatus(StatusCliente status);
 
+    List<Cliente> findByStatusOrderByNomeAsc(StatusCliente status);
+
+    List<Cliente> findByStatusOrderByCreatedAtAsc(StatusCliente status);
+
     boolean existsByCpf(String cpf);
 
     boolean existsByEmail(String email);

--- a/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/presentation/rest/ClienteController.java
+++ b/backend/ms-cliente/src/main/java/com/ufpr/bantads/cliente/presentation/rest/ClienteController.java
@@ -2,11 +2,13 @@ package com.ufpr.bantads.cliente.presentation.rest;
 
 import java.util.List;
 
+import com.ufpr.bantads.cliente.application.dto.request.AlterarPerfilRequest;
 import com.ufpr.bantads.cliente.application.dto.request.CriarClientePendenteRequest;
 import com.ufpr.bantads.cliente.application.dto.request.RejeitarClienteRequest;
 import com.ufpr.bantads.cliente.application.dto.response.ClienteParaAprovarResponse;
 import com.ufpr.bantads.cliente.application.dto.response.ClienteResponse;
 import com.ufpr.bantads.cliente.application.dto.response.CriarClientePendenteResponse;
+import com.ufpr.bantads.cliente.application.usecase.AlterarPerfilUseCase;
 import com.ufpr.bantads.cliente.application.usecase.AprovarClienteUseCase;
 import com.ufpr.bantads.cliente.application.usecase.CriarClientePendenteUseCase;
 import com.ufpr.bantads.cliente.application.usecase.GetClienteByCpfUseCase;
@@ -18,9 +20,9 @@ import org.springframework.http.HttpStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,6 +37,7 @@ public class ClienteController {
     private final GetClienteByCpfUseCase getClienteByCpfUseCase;
     private final AprovarClienteUseCase aprovarClienteUseCase;
     private final RejeitarClienteUseCase rejeitarClienteUseCase;
+    private final AlterarPerfilUseCase alterarPerfilUseCase;
 
 
     @GetMapping("/clientes")
@@ -64,18 +67,27 @@ public class ClienteController {
             .body(CriarClientePendenteResponse.fromEntity(cliente));
     }
 
-    @PatchMapping("/clientes/{cpf}/aprovar")
+    @PostMapping("/clientes/{cpf}/aprovar")
     public ResponseEntity<ClienteResponse> aprovarCliente(@PathVariable String cpf) {
         ClienteResponse cliente = aprovarClienteUseCase.execute(cpf);
         return ResponseEntity.ok(cliente);
     }
 
-    @PatchMapping("/clientes/{cpf}/rejeitar")
+    @PostMapping("/clientes/{cpf}/rejeitar")
     public ResponseEntity<ClienteResponse> rejeitarCliente(
         @PathVariable String cpf,
         @Valid @RequestBody RejeitarClienteRequest request
     ) {
         ClienteResponse cliente = rejeitarClienteUseCase.execute(cpf, request.motivo());
+        return ResponseEntity.ok(cliente);
+    }
+
+    @PutMapping("/clientes/{cpf}")
+    public ResponseEntity<ClienteResponse> alterarPerfil(
+        @PathVariable String cpf,
+        @Valid @RequestBody AlterarPerfilRequest request
+    ) {
+        ClienteResponse cliente = alterarPerfilUseCase.execute(cpf, request);
         return ResponseEntity.ok(cliente);
     }
 }


### PR DESCRIPTION
Comportamentos corrigidos

POST /clientes/{cpf}/aprovar - R10
POST /clientes/{cpf}/rejeitar - R11
PUT /clientes/{cpf} adicionado - R04
GET /clientes agora ordena por nome crescente - R12
GET /clientes?filtro=para_aprovar agora ordena por data de criação - R09
GET /clientes/{cpf} retorna 404 quando o cliente está com status REJEITADO - R11/R13
GetClienteByCpfUseCase.java - lança 404 para REJEITADO
