### PR TITLE
feat: adicionado rota de composition para o gerente listar os clientes

### DIFF
--- a/backend/api-gateway/src/routes/composition/gerenteClientes.ts
+++ b/backend/api-gateway/src/routes/composition/gerenteClientes.ts
@@ -1,0 +1,62 @@
+import type { FastifyInstance } from 'fastify';
+import type { ClienteMsResponse, ClientResponseDto } from '../../types/dto/cliente.ts';
+import type { ContaMsResponse } from '../../types/dto/conta.ts';
+import { httpClient } from '../../services/http-client.ts';
+import { env } from '../../config/env.ts';
+import { buildUpstreamHeaders } from '../../hooks/upstream-headers.ts';
+import { authorize } from '../../middlewares/authenticate.ts';
+
+type GerenteCpfParams = {
+  cpf: string;
+};
+
+export async function registerGerenteClientes(gateway: FastifyInstance) {
+  gateway.get<{ Params: GerenteCpfParams; Reply: ClientResponseDto[] }>(
+    '/gerentes/:cpf/clientes',
+    { preHandler: authorize('GERENTE') },
+    async (request) => {
+      const { cpf } = request.params;
+      const headers = buildUpstreamHeaders(request);
+
+      const [contas, clientes] = await Promise.all([
+        httpClient.get<ContaMsResponse[]>(
+          `${env.upstreams.conta}/contas?gerenteCpf=${encodeURIComponent(cpf)}`,
+          headers,
+        ),
+        httpClient.get<ClienteMsResponse[]>(
+          `${env.upstreams.cliente}/clientes`,
+          headers,
+        ),
+      ]);
+
+      const clientesPorCpf = new Map(
+        clientes.map((c) => [c.cpf, c]),
+      );
+
+      return contas
+        .map((conta) => {
+          const cliente = clientesPorCpf.get(conta.clienteCpf);
+          if (!cliente) return null;
+
+          return {
+            cpf: cliente.cpf,
+            nome: cliente.nome,
+            telefone: cliente.telefone,
+            email: cliente.email,
+            cep: cliente.CEP,
+            endereco: cliente.endereco,
+            cidade: cliente.cidade,
+            estado: cliente.estado,
+            salario: cliente.salario,
+            conta: conta.numeroConta,
+            saldo: String(conta.saldo),
+            limite: conta.limite,
+            gerente: conta.gerenteCpf,
+            gerente_nome: conta.gerenteNome,
+            gerente_email: conta.gerenteEmail,
+          };
+        })
+        .filter((item): item is ClientResponseDto => item !== null);
+    },
+  );
+}

--- a/backend/api-gateway/src/server.ts
+++ b/backend/api-gateway/src/server.ts
@@ -11,6 +11,7 @@ import { env } from './config/env.ts';
 import { registerClientByCpf } from './routes/composition/clientByCpf.ts';
 import { registerCreateGerenteSaga } from './routes/composition/createGerenteSaga.ts';
 import { registerGerentesComposition } from './routes/composition/gerentes.ts';
+import { registerGerenteClientes } from './routes/composition/gerenteClientes.ts';
 
 const gateway = Fastify({
   logger: true,
@@ -23,6 +24,7 @@ await gateway.register(jwtPlugin);
 await registerAuthRoutes(gateway);
 await registerClientByCpf(gateway);
 await registerGerentesComposition(gateway);
+await registerGerenteClientes(gateway);
 await registerCreateGerenteSaga(gateway);
 await registerClienteRoutes(gateway);
 

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/presentation/rest/ContaController.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/presentation/rest/ContaController.java
@@ -31,6 +31,7 @@ import com.ufpr.bantads.conta.application.usecase.SacarUseCase;
 import com.ufpr.bantads.conta.application.usecase.TransferenciaUseCase;
 import com.ufpr.bantads.conta.domain.exception.ContaJaExisteException;
 import com.ufpr.bantads.conta.domain.exception.NumeroContaIndisponivelException;
+import com.ufpr.bantads.conta.domain.repository.ContaQueryRepository;
 import com.ufpr.bantads.conta.infrastructure.config.ContaSeedService;
 
 import lombok.RequiredArgsConstructor;
@@ -48,6 +49,7 @@ public class ContaController {
     private final GetContaByCpfUseCase contaByCpfUseCase;
     private final GetResumoContasGerentesUseCase resumoContasGerentesUseCase;
     private final CriarContaUseCase criarContaUseCase;
+    private final ContaQueryRepository contaQueryRepository;
     private final ContaSeedService contaSeedService;
 
     @GetMapping("/reboot")
@@ -70,6 +72,15 @@ public class ContaController {
     public ResponseEntity<ContaResponse> getByClienteCpf(@RequestParam String clienteCpf) {
         ContaResponse contaResponse = contaByCpfUseCase.execute(clienteCpf);
         return ResponseEntity.ok(contaResponse);
+    }
+
+    @GetMapping(value = "/contas", params = "gerenteCpf")
+    public ResponseEntity<List<ContaResponse>> getByGerenteCpf(@RequestParam String gerenteCpf) {
+        List<ContaResponse> contas = contaQueryRepository.findByGerenteCpf(gerenteCpf)
+                .stream()
+                .map(ContaResponse::fromEntity)
+                .toList();
+        return ResponseEntity.ok(contas);
     }
 
     @GetMapping("/contas/resumo-gerentes")


### PR DESCRIPTION
closes #134 

A tela /gerentes/todos-clientes no front estava retornando 403 por que o request estava caindo em /gerentes que era adminOnly. Agora existe uma rota especifica pra isso: 
- GET /gerentes/:cpf/clientes - API gateway com authorize para GERENTE