### PR TITLE
feat: compor relatório de clientes no gateway

### DIFF
--- a/backend/api-gateway/src/routes/clientes.ts
+++ b/backend/api-gateway/src/routes/clientes.ts
@@ -3,9 +3,15 @@ import { env } from '../config/env.ts';
 import { buildUpstreamHeaders } from '../hooks/upstream-headers.ts';
 import { authenticate, authorize } from '../middlewares/authenticate.ts';
 import { httpClient } from '../services/http-client.ts';
+import type { ClienteMsResponse, ClientResponseDto } from '../types/dto/cliente.ts';
+import type { ResumoContasGerenteMsResponse } from '../types/dto/conta.ts';
 
 type ClienteParams = {
   cpf: string;
+};
+
+type ClientesQuery = {
+  filtro?: string;
 };
 
 type RejeitarClienteBody = {
@@ -30,7 +36,18 @@ export async function registerClienteRoutes(gateway: FastifyInstance) {
     return reply.code(201).send(response);
   });
 
-  gateway.get('/clientes', { preHandler: authenticate }, async (request, reply) => {
+  gateway.get<{ Querystring: ClientesQuery }>('/clientes', { preHandler: authenticate }, async (request, reply) => {
+    if (isRelatorioClientes(request.query)) {
+      await authorize('ADMINISTRADOR')(request, reply);
+
+      const response = await getClientesRelatorio(
+        request.raw.url ?? request.url,
+        buildUpstreamHeaders(request),
+      );
+
+      return reply.code(200).send(response);
+    }
+
     const response = await httpClient.get<unknown>(
       buildClientesUrl(request.raw.url ?? request.url),
       buildUpstreamHeaders(request),
@@ -86,4 +103,52 @@ export async function registerClienteRoutes(gateway: FastifyInstance) {
       return reply.code(200).send(response);
     },
   );
+}
+
+function isRelatorioClientes(query: ClientesQuery): boolean {
+  return query.filtro === 'adm_relatorio_clientes';
+}
+
+async function getClientesRelatorio(
+  requestUrl: string,
+  headers: Record<string, string>,
+): Promise<ClientResponseDto[]> {
+  const clientesUrl = new URL(buildClientesUrl(requestUrl));
+  clientesUrl.searchParams.delete('filtro');
+
+  const [clientes, resumosContas] = await Promise.all([
+    httpClient.get<ClienteMsResponse[]>(clientesUrl.toString(), headers),
+    httpClient.get<ResumoContasGerenteMsResponse[]>(
+      `${env.upstreams.conta}/contas/resumo-gerentes`,
+      headers,
+    ),
+  ]);
+
+  const contasPorCpf = new Map(
+    resumosContas
+      .flatMap((resumo) => resumo.clientes)
+      .map((conta) => [conta.clienteCpf, conta]),
+  );
+
+  return clientes.map((cliente) => {
+    const conta = contasPorCpf.get(cliente.cpf);
+
+    return {
+      cpf: cliente.cpf,
+      nome: cliente.nome,
+      telefone: cliente.telefone,
+      email: cliente.email,
+      cep: cliente.CEP,
+      endereco: cliente.endereco,
+      cidade: cliente.cidade,
+      estado: cliente.estado,
+      salario: cliente.salario,
+      conta: conta?.numeroConta ?? '',
+      saldo: String(conta?.saldo ?? 0),
+      limite: conta?.limite ?? 0,
+      gerente: conta?.gerenteCpf ?? '',
+      gerente_nome: conta?.gerenteNome ?? '',
+      gerente_email: conta?.gerenteEmail ?? '',
+    };
+  });
 }

--- a/backend/api-gateway/src/routes/composition/gerentes.ts
+++ b/backend/api-gateway/src/routes/composition/gerentes.ts
@@ -3,12 +3,11 @@ import { env } from '../../config/env.ts';
 import { buildUpstreamHeaders } from '../../hooks/upstream-headers.ts';
 import { authorize } from '../../middlewares/authenticate.ts';
 import { httpClient } from '../../services/http-client.ts';
+import type { ContaMsResponse, ResumoContasGerenteMsResponse } from '../../types/dto/conta.ts';
 import type {
   ClienteDashboardResponse,
-  ContaGerenteMsResponse,
   GerenteDashboardResponse,
   GerenteMsResponse,
-  ResumoContasGerenteMsResponse,
 } from '../../types/dto/gerente.ts';
 
 type GerentesQuery = {
@@ -90,7 +89,7 @@ function montarResumoGerente(
   };
 }
 
-function toClienteDashboard(conta: ContaGerenteMsResponse): ClienteDashboardResponse {
+function toClienteDashboard(conta: ContaMsResponse): ClienteDashboardResponse {
   return {
     cliente: conta.clienteCpf,
     numero: conta.numeroConta,

--- a/backend/api-gateway/src/types/dto/conta.ts
+++ b/backend/api-gateway/src/types/dto/conta.ts
@@ -9,3 +9,10 @@ export type ContaMsResponse = {
   gerenteNome: string;
   gerenteEmail: string;
 };
+
+export type ResumoContasGerenteMsResponse = {
+  gerenteCpf: string;
+  clientes: ContaMsResponse[];
+  saldoPositivo: number;
+  saldoNegativo: number;
+};

--- a/backend/api-gateway/src/types/dto/gerente.ts
+++ b/backend/api-gateway/src/types/dto/gerente.ts
@@ -22,17 +22,6 @@ export type InserirGerenteSagaResponse = {
   tipo: string;
 };
 
-export type ContaGerenteMsResponse = {
-  numeroConta: string;
-  dataCriacao: string;
-  saldo: number;
-  limite: number;
-  clienteNome: string;
-  clienteCpf: string;
-  gerenteCpf: string;
-  gerenteNome: string;
-};
-
 export type ClienteDashboardResponse = {
   cliente: string;
   numero: string;
@@ -40,13 +29,6 @@ export type ClienteDashboardResponse = {
   limite: number;
   gerente: string;
   criacao: string;
-};
-
-export type ResumoContasGerenteMsResponse = {
-  gerenteCpf: string;
-  clientes: ContaGerenteMsResponse[];
-  saldoPositivo: number;
-  saldoNegativo: number;
 };
 
 export type GerenteDashboardResponse = {

--- a/frontend/app/lib/utils/formatCurrency.ts
+++ b/frontend/app/lib/utils/formatCurrency.ts
@@ -1,8 +1,14 @@
 const LANG = "pt-BR";
 const CURRENCY = "BRL";
 
-function getFormattedCurrency(value: number):string {
-  return value.toLocaleString(
+function getFormattedCurrency(value: number | string | null | undefined): string {
+  const numericValue = typeof value === "string" ? Number(value) : value;
+
+  if (numericValue == null || !Number.isFinite(numericValue)) {
+    return "-";
+  }
+
+  return numericValue.toLocaleString(
     LANG,
     {
       style: "currency",

--- a/frontend/app/routes/admin/relatorio-clientes.tsx
+++ b/frontend/app/routes/admin/relatorio-clientes.tsx
@@ -1,7 +1,6 @@
-
 import { AppBreadcrumb } from "~/components/app-breadcrumb";
 import { getSessionAutenticada } from "~/services/auth.server";
-import { Clipboard, LayoutDashboard } from "lucide-react";
+import { Clipboard } from "lucide-react";
 import type { Cliente } from "~/models/dto/Cliente";
 import { TabelaAdminClientes } from "~/features/tabela-admin-clientes/tabela-admin-clientes";
 import type { Route } from "./+types/relatorio-clientes";
@@ -15,7 +14,7 @@ export function meta({}: Route.MetaArgs) {
 
 export async function loader({ request }: Route.LoaderArgs) {
     const { apiClient } = await getSessionAutenticada(request);
-    const response = await apiClient.get("/clientes");
+    const response = await apiClient.get("/clientes?filtro=adm_relatorio_clientes");
 
     if (!response.ok) {
         throw new Response("Erro ao carregar tela de relatório de clientes", { status: response.status });


### PR DESCRIPTION
Ajusta o relatório de clientes para usar `filtro=adm_relatorio_clientes`, conforme esperado pelo testador, compondo os dados no API Gateway.

closes #136 