### PR TITLE
fix: corrige saldo como número e arredondamento monetário

### DIFF
--- a/backend/api-gateway/src/routes/clientes.ts
+++ b/backend/api-gateway/src/routes/clientes.ts
@@ -48,7 +48,7 @@ export async function registerClienteRoutes(gateway: FastifyInstance) {
     if (isMelhoresClientes(request.query)) {
       const todos = await getClientesRelatorio(buildUpstreamHeaders(request));
       const top3 = todos
-        .sort((a, b) => parseFloat(b.saldo) - parseFloat(a.saldo))
+        .sort((a, b) => b.saldo - a.saldo)
         .slice(0, 3);
       return reply.code(200).send(top3);
     }
@@ -155,7 +155,7 @@ async function getClientesRelatorio(
       estado: cliente.estado,
       salario: cliente.salario,
       conta: conta?.numeroConta ?? '',
-      saldo: String(conta?.saldo ?? 0),
+      saldo: conta?.saldo ?? 0,
       limite: conta?.limite ?? 0,
       gerente: conta?.gerenteCpf ?? '',
       gerente_nome: conta?.gerenteNome ?? '',

--- a/backend/api-gateway/src/routes/composition/clientByCpf.ts
+++ b/backend/api-gateway/src/routes/composition/clientByCpf.ts
@@ -56,7 +56,7 @@ export async function registerClientByCpf(gateway: FastifyInstance) {
             estado: cliente.estado,
             salario: cliente.salario,
             conta: conta.numeroConta,
-            saldo: String(conta.saldo),
+            saldo: conta.saldo,
             limite: conta.limite,
             gerente: conta.gerenteCpf,
             gerente_nome: conta.gerenteNome,

--- a/backend/api-gateway/src/routes/composition/gerenteClientes.ts
+++ b/backend/api-gateway/src/routes/composition/gerenteClientes.ts
@@ -49,7 +49,7 @@ export async function registerGerenteClientes(gateway: FastifyInstance) {
             estado: cliente.estado,
             salario: cliente.salario,
             conta: conta.numeroConta,
-            saldo: String(conta.saldo),
+            saldo: conta.saldo,
             limite: conta.limite,
             gerente: conta.gerenteCpf,
             gerente_nome: conta.gerenteNome,

--- a/backend/api-gateway/src/types/dto/cliente.ts
+++ b/backend/api-gateway/src/types/dto/cliente.ts
@@ -9,7 +9,7 @@ export type ClientResponseDto = {
   estado: string;
   salario: number;
   conta: string;
-  saldo: string;
+  saldo: number;
   limite: number;
   gerente: string;
   gerente_nome: string;

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/DepositarUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/DepositarUseCase.java
@@ -1,6 +1,7 @@
 package com.ufpr.bantads.conta.application.usecase;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -34,13 +35,15 @@ public class DepositarUseCase {
         ContaCommand conta = contaCommandRepository.findByNumeroConta(numeroConta)
             .orElseThrow(() -> new IllegalArgumentException("Conta não encontrada"));
 
-        Double saldo = conta.getSaldo().doubleValue() + valor;
-        conta.setSaldo(BigDecimal.valueOf(saldo));
+        BigDecimal valorDeposito = BigDecimal.valueOf(valor).setScale(2, RoundingMode.HALF_UP);
+        BigDecimal novoSaldo = conta.getSaldo().add(valorDeposito).setScale(2, RoundingMode.HALF_UP);
+
+        conta.setSaldo(novoSaldo);
         contaCommandRepository.save(conta);
 
         DepositoCommand deposito = DepositoCommand.builder()
             .contaId(conta.getId())
-            .valor(BigDecimal.valueOf(valor))
+            .valor(valorDeposito)
             .build();
 
         depositoCommandRepository.save(deposito);

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/SacarUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/SacarUseCase.java
@@ -1,6 +1,7 @@
 package com.ufpr.bantads.conta.application.usecase;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -34,21 +35,20 @@ public class SacarUseCase {
         ContaCommand conta = contaCommandRepository.findByNumeroConta(numeroConta)
                 .orElseThrow(() -> new IllegalArgumentException("Conta não encontrada"));
 
-        Double saldoAtual = conta.getSaldo().doubleValue();
-        Double limite = conta.getLimite().doubleValue();
+        BigDecimal valorSaque = BigDecimal.valueOf(valor).setScale(2, RoundingMode.HALF_UP);
 
-        if ((saldoAtual + limite) < valor) {
+        if (conta.getSaldo().add(conta.getLimite()).compareTo(valorSaque) < 0) {
             throw new IllegalArgumentException("Saldo insuficiente considerando o limite");
         }
 
 
-        Double novoSaldo = saldoAtual - valor;
-        conta.setSaldo(BigDecimal.valueOf(novoSaldo));
+        BigDecimal novoSaldo = conta.getSaldo().subtract(valorSaque).setScale(2, RoundingMode.HALF_UP);
+        conta.setSaldo(novoSaldo);
         contaCommandRepository.save(conta);
 
         SaqueCommand saque = SaqueCommand.builder()
                 .contaId(conta.getId())
-                .valor(BigDecimal.valueOf(valor))
+                .valor(valorSaque)
                 .build();
 
         saqueCommandRepository.save(saque);

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/TransferenciaUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/TransferenciaUseCase.java
@@ -1,6 +1,7 @@
 package com.ufpr.bantads.conta.application.usecase;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -42,26 +43,26 @@ public class TransferenciaUseCase {
         ContaCommand contaDestino = contaCommandRepository.findByNumeroConta(numeroContaDestino)
                 .orElseThrow(() -> new IllegalArgumentException("Conta de destino não encontrada"));
 
-        Double saldoOrigem = contaOrigem.getSaldo().doubleValue();
-        Double limiteOrigem = contaOrigem.getLimite().doubleValue();
+        BigDecimal valorTransferencia = BigDecimal.valueOf(valor).setScale(2, RoundingMode.HALF_UP);
 
-        if ((saldoOrigem + limiteOrigem) < valor) {
+        if (contaOrigem.getSaldo().add(contaOrigem.getLimite()).compareTo(valorTransferencia) < 0) {
             throw new IllegalArgumentException("Saldo insuficiente para transferência");
         }
 
-        Double novoSaldoOrigem = saldoOrigem - valor;
-        contaOrigem.setSaldo(BigDecimal.valueOf(novoSaldoOrigem));
+        BigDecimal novoSaldoOrigem =
+            contaOrigem.getSaldo().subtract(valorTransferencia).setScale(2, RoundingMode.HALF_UP);
+        contaOrigem.setSaldo(novoSaldoOrigem);
         contaCommandRepository.save(contaOrigem);
 
-        Double saldoDestino = contaDestino.getSaldo().doubleValue();
-        Double novoSaldoDestino = saldoDestino + valor;
-        contaDestino.setSaldo(BigDecimal.valueOf(novoSaldoDestino));
+        BigDecimal novoSaldoDestino =
+            contaDestino.getSaldo().add(valorTransferencia).setScale(2, RoundingMode.HALF_UP);
+        contaDestino.setSaldo(novoSaldoDestino);
         contaCommandRepository.save(contaDestino);
 
         TransferenciaCommand transferencia = TransferenciaCommand.builder()
                 .contaOrigemId(contaOrigem.getId())
                 .contaDestinoId(contaDestino.getId())
-                .valor(BigDecimal.valueOf(valor))
+                .valor(valorTransferencia)
                 .build();
 
         transferenciaCommandRepository.save(transferencia);
@@ -70,7 +71,7 @@ public class TransferenciaUseCase {
                 .eventId(UUID.randomUUID().toString())
                 .movimentacaoId(transferencia.getId())
                 .tipo(TipoMovimentacao.TRANSFERENCIA)
-                .valor(BigDecimal.valueOf(valor))
+                .valor(valorTransferencia)
                 .dataHora(transferencia.getDataHora())
                 .numeroContaOrigem(contaOrigem.getNumeroConta())
                 .numeroContaDestino(contaDestino.getNumeroConta())


### PR DESCRIPTION
- retorna saldo como number nos DTOs compostos do gateway
- remove parseFloat desnecessário no ranking de melhores clientes
- usa BigDecimal com escala 2 em depósito, saque e transferência
- evita resíduos de ponto flutuante nos cálculos de saldo

closes #161 