### PR TITLE
Cache no ms-conta para consulta logo depois de movimentação

### DIFF
--- a/backend/ms-conta/pom.xml
+++ b/backend/ms-conta/pom.xml
@@ -40,6 +40,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/dto/response/ContaResponse.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/dto/response/ContaResponse.java
@@ -26,4 +26,19 @@ public record ContaResponse(
             contaQuery.getGerenteEmail()
         );
     }
+
+    public static ContaResponse fromEntity(ContaQuery contaQuery , double saldo) {
+                
+        return new ContaResponse(
+            contaQuery.getNumeroConta(),
+            contaQuery.getDataCriacao().toString(),
+            saldo,
+            contaQuery.getLimite().doubleValue(),
+            contaQuery.getClienteNome(),
+            contaQuery.getClienteCpf(),
+            contaQuery.getGerenteCpf(),
+            contaQuery.getGerenteNome(),
+            contaQuery.getGerenteEmail()
+        );
+    }
 }

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/dto/response/TransferenciaResponse.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/dto/response/TransferenciaResponse.java
@@ -2,6 +2,8 @@ package com.ufpr.bantads.conta.application.dto.response;
 
 public record TransferenciaResponse(
     String conta,
+    String destino,
+    Double valor,
     Double saldo,
     String data
 ) {}

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/DepositarUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/DepositarUseCase.java
@@ -14,6 +14,8 @@ import com.ufpr.bantads.conta.domain.model.entity.DepositoCommand;
 import com.ufpr.bantads.conta.domain.model.enums.TipoMovimentacao;
 import com.ufpr.bantads.conta.domain.repository.ContaCommandRepository;
 import com.ufpr.bantads.conta.domain.repository.DepositoCommandRepository;
+import com.ufpr.bantads.conta.infrastructure.cache.redis.model.ContaCache;
+import com.ufpr.bantads.conta.infrastructure.cache.redis.repository.ContaCacheRedisRepository;
 import com.ufpr.bantads.conta.infrastructure.messaging.publisher.MovimentacaoEventPublisher;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,8 @@ public class DepositarUseCase {
     private final ContaCommandRepository contaCommandRepository;
 
     private final DepositoCommandRepository depositoCommandRepository;
+
+    private final ContaCacheRedisRepository cacheRedisRepository;
 
     private final MovimentacaoEventPublisher movimentacaoEventPublisher;
 
@@ -47,14 +51,25 @@ public class DepositarUseCase {
             .build();
 
         depositoCommandRepository.save(deposito);
+
+        String eventId = UUID.randomUUID().toString();
+
         movimentacaoEventPublisher.publish(MovimentacaoEvent.builder()
-            .eventId(UUID.randomUUID().toString())
+            .eventId(eventId)
             .movimentacaoId(deposito.getId())
             .tipo(TipoMovimentacao.DEPOSITO)
             .valor(deposito.getValor())
             .dataHora(deposito.getDataHora())
             .numeroContaOrigem(conta.getNumeroConta())
             .novoSaldoContaOrigem(conta.getSaldo())
+            .build());
+
+        cacheRedisRepository.save(ContaCache.builder()
+            .id(ContaCache.idForNumeroConta(conta.getNumeroConta()))
+            .clienteCpf(conta.getClienteCpf())
+            .numeroConta(conta.getNumeroConta())
+            .saldo(novoSaldo)
+            .eventId(eventId)
             .build());
 
         return new DepositoSaqueResponse(

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/DepositarUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/DepositarUseCase.java
@@ -65,7 +65,6 @@ public class DepositarUseCase {
             .build());
 
         cacheRedisRepository.save(ContaCache.builder()
-            .id(ContaCache.idForNumeroConta(conta.getNumeroConta()))
             .clienteCpf(conta.getClienteCpf())
             .numeroConta(conta.getNumeroConta())
             .saldo(novoSaldo)

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/GetContaByCpfUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/GetContaByCpfUseCase.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 
 import com.ufpr.bantads.conta.application.dto.response.ContaResponse;
 import com.ufpr.bantads.conta.domain.repository.ContaQueryRepository;
+import com.ufpr.bantads.conta.infrastructure.cache.redis.model.ContaCache;
+import com.ufpr.bantads.conta.infrastructure.cache.redis.repository.ContaCacheRedisRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,9 +15,21 @@ public class GetContaByCpfUseCase {
 
     private final ContaQueryRepository contaQueryRepository;
 
+    private final ContaCacheRedisRepository cacheRedisRepository;
+
     public ContaResponse execute(String cpf) {
         return contaQueryRepository.findByClienteCpf(cpf)
-            .map(ContaResponse::fromEntity)
+            .map(conta -> {
+                ContaCache cache = cacheRedisRepository
+                    .findById(ContaCache.idForNumeroConta(conta.getNumeroConta()))
+                    .orElse(null);
+
+                if (cache != null) {
+                    return ContaResponse.fromEntity(conta, cache.getSaldo().doubleValue());
+                }
+
+                return ContaResponse.fromEntity(conta);
+            })
             .orElseThrow(() -> new IllegalArgumentException("Conta não encontrada"));
     }
 

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/GetContaByCpfUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/GetContaByCpfUseCase.java
@@ -21,7 +21,7 @@ public class GetContaByCpfUseCase {
         return contaQueryRepository.findByClienteCpf(cpf)
             .map(conta -> {
                 ContaCache cache = cacheRedisRepository
-                    .findById(ContaCache.idForNumeroConta(conta.getNumeroConta()))
+                    .findById(conta.getNumeroConta())
                     .orElse(null);
 
                 if (cache != null) {

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/GetExtratoUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/GetExtratoUseCase.java
@@ -23,7 +23,7 @@ public class GetExtratoUseCase {
             .orElseThrow(() -> new IllegalArgumentException("Conta não encontrada"));
 
         List<Extrato> movimentacoes = movimentacaoQueryRepository
-            .findByContaOrigemNumeroOrContaDestinoNumero(numeroConta, numeroConta)
+            .findByContaOrigemNumeroOrContaDestinoNumeroOrderByDataHoraAsc(numeroConta, numeroConta)
             .stream()
             .map(Extrato::fromEntity)
             .toList();

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/GetSaldoUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/GetSaldoUseCase.java
@@ -18,7 +18,7 @@ public class GetSaldoUseCase {
     private final ContaCacheRedisRepository cacheRedisRepository;
 
     public SaldoResponse execute(String conta) {
-        ContaCache cache = cacheRedisRepository.findById(ContaCache.idForNumeroConta(conta)).orElse(null);
+        ContaCache cache = cacheRedisRepository.findById(conta).orElse(null);
 
         if (cache != null) {
             return new SaldoResponse(

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/GetSaldoUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/GetSaldoUseCase.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 
 import com.ufpr.bantads.conta.application.dto.response.SaldoResponse;
 import com.ufpr.bantads.conta.domain.repository.ContaQueryRepository;
+import com.ufpr.bantads.conta.infrastructure.cache.redis.model.ContaCache;
+import com.ufpr.bantads.conta.infrastructure.cache.redis.repository.ContaCacheRedisRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,7 +15,19 @@ public class GetSaldoUseCase {
 
     private final ContaQueryRepository contaQueryRepository;
 
+    private final ContaCacheRedisRepository cacheRedisRepository;
+
     public SaldoResponse execute(String conta) {
+        ContaCache cache = cacheRedisRepository.findById(ContaCache.idForNumeroConta(conta)).orElse(null);
+
+        if (cache != null) {
+            return new SaldoResponse(
+                cache.getClienteCpf(),
+                cache.getNumeroConta(),
+                cache.getSaldo().doubleValue()
+            );
+        }
+
         return contaQueryRepository.findByNumeroConta(conta)
             .map(SaldoResponse::fromEntity)
             .orElseThrow(() -> new IllegalArgumentException("Conta não encontrada"));

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/SacarUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/SacarUseCase.java
@@ -70,7 +70,6 @@ public class SacarUseCase {
                 .build());
 
         cacheRedisRepository.save(ContaCache.builder()
-                .id(ContaCache.idForNumeroConta(conta.getNumeroConta()))
                 .clienteCpf(conta.getClienteCpf())
                 .numeroConta(conta.getNumeroConta())
                 .eventId(eventId)

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/SacarUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/SacarUseCase.java
@@ -14,6 +14,8 @@ import com.ufpr.bantads.conta.domain.model.entity.SaqueCommand;
 import com.ufpr.bantads.conta.domain.model.enums.TipoMovimentacao;
 import com.ufpr.bantads.conta.domain.repository.ContaCommandRepository;
 import com.ufpr.bantads.conta.domain.repository.SaqueCommandRepository;
+import com.ufpr.bantads.conta.infrastructure.cache.redis.model.ContaCache;
+import com.ufpr.bantads.conta.infrastructure.cache.redis.repository.ContaCacheRedisRepository;
 import com.ufpr.bantads.conta.infrastructure.messaging.publisher.MovimentacaoEventPublisher;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,8 @@ public class SacarUseCase {
     private final ContaCommandRepository contaCommandRepository;
 
     private final SaqueCommandRepository saqueCommandRepository;
+
+    private final ContaCacheRedisRepository cacheRedisRepository;
 
     private final MovimentacaoEventPublisher movimentacaoEventPublisher;
 
@@ -53,14 +57,24 @@ public class SacarUseCase {
 
         saqueCommandRepository.save(saque);
 
+        String eventId = UUID.randomUUID().toString();
+
         movimentacaoEventPublisher.publish(MovimentacaoEvent.builder()
-                .eventId(UUID.randomUUID().toString())
+                .eventId(eventId)
                 .movimentacaoId(saque.getId())
                 .tipo(TipoMovimentacao.SAQUE)
                 .valor(saque.getValor())
                 .dataHora(saque.getDataHora())
                 .numeroContaOrigem(conta.getNumeroConta())
                 .novoSaldoContaOrigem(conta.getSaldo())
+                .build());
+
+        cacheRedisRepository.save(ContaCache.builder()
+                .id(ContaCache.idForNumeroConta(conta.getNumeroConta()))
+                .clienteCpf(conta.getClienteCpf())
+                .numeroConta(conta.getNumeroConta())
+                .eventId(eventId)
+                .saldo(novoSaldo)
                 .build());
 
         return new DepositoSaqueResponse(

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/SyncMovimentacaoUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/SyncMovimentacaoUseCase.java
@@ -2,6 +2,7 @@ package com.ufpr.bantads.conta.application.usecase;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.context.ApplicationEventPublisher;
 
 import com.ufpr.bantads.conta.application.dto.event.ContaCriadaEvent;
 import com.ufpr.bantads.conta.application.dto.event.ContaExcluidaEvent;
@@ -19,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 public class SyncMovimentacaoUseCase {
 
     private final MovimentacaoQueryRepository movimentacaoQueryRepository;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     private final ContaQueryRepository contaQueryRepository;
 
@@ -85,6 +88,8 @@ public class SyncMovimentacaoUseCase {
             default:
                 break;
         }
+
+        eventPublisher.publishEvent(event);
         
     }
 

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/TransferenciaUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/TransferenciaUseCase.java
@@ -86,7 +86,6 @@ public class TransferenciaUseCase {
                 .build());
 
         cacheRedisRepository.save(ContaCache.builder()
-                .id(ContaCache.idForNumeroConta(contaOrigem.getNumeroConta()))
                 .clienteCpf(contaOrigem.getClienteCpf())
                 .numeroConta(contaOrigem.getNumeroConta())
                 .eventId(eventId)
@@ -94,7 +93,6 @@ public class TransferenciaUseCase {
                 .build());
 
         cacheRedisRepository.save(ContaCache.builder()
-                .id(ContaCache.idForNumeroConta(contaDestino.getNumeroConta()))
                 .clienteCpf(contaDestino.getClienteCpf())
                 .numeroConta(contaDestino.getNumeroConta())
                 .eventId(eventId)

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/TransferenciaUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/TransferenciaUseCase.java
@@ -14,6 +14,8 @@ import com.ufpr.bantads.conta.domain.model.entity.TransferenciaCommand;
 import com.ufpr.bantads.conta.domain.model.enums.TipoMovimentacao;
 import com.ufpr.bantads.conta.domain.repository.ContaCommandRepository;
 import com.ufpr.bantads.conta.domain.repository.TransferenciaCommandRepository;
+import com.ufpr.bantads.conta.infrastructure.cache.redis.model.ContaCache;
+import com.ufpr.bantads.conta.infrastructure.cache.redis.repository.ContaCacheRedisRepository;
 import com.ufpr.bantads.conta.infrastructure.messaging.publisher.MovimentacaoEventPublisher;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,8 @@ public class TransferenciaUseCase {
     private final ContaCommandRepository contaCommandRepository;
 
     private final TransferenciaCommandRepository transferenciaCommandRepository;
+
+    private final ContaCacheRedisRepository cacheRedisRepository;
 
     private final MovimentacaoEventPublisher movimentacaoEventPublisher;
 
@@ -67,8 +71,10 @@ public class TransferenciaUseCase {
 
         transferenciaCommandRepository.save(transferencia);
 
+        String eventId = UUID.randomUUID().toString();
+
         movimentacaoEventPublisher.publish(MovimentacaoEvent.builder()
-                .eventId(UUID.randomUUID().toString())
+                .eventId(eventId)
                 .movimentacaoId(transferencia.getId())
                 .tipo(TipoMovimentacao.TRANSFERENCIA)
                 .valor(valorTransferencia)
@@ -77,6 +83,22 @@ public class TransferenciaUseCase {
                 .numeroContaDestino(contaDestino.getNumeroConta())
                 .novoSaldoContaOrigem(contaOrigem.getSaldo())
                 .novoSaldoContaDestino(contaDestino.getSaldo())
+                .build());
+
+        cacheRedisRepository.save(ContaCache.builder()
+                .id(ContaCache.idForNumeroConta(contaOrigem.getNumeroConta()))
+                .clienteCpf(contaOrigem.getClienteCpf())
+                .numeroConta(contaOrigem.getNumeroConta())
+                .eventId(eventId)
+                .saldo(novoSaldoOrigem)
+                .build());
+
+        cacheRedisRepository.save(ContaCache.builder()
+                .id(ContaCache.idForNumeroConta(contaDestino.getNumeroConta()))
+                .clienteCpf(contaDestino.getClienteCpf())
+                .numeroConta(contaDestino.getNumeroConta())
+                .eventId(eventId)
+                .saldo(novoSaldoDestino)
                 .build());
         
         return new TransferenciaResponse(

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/TransferenciaUseCase.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/application/usecase/TransferenciaUseCase.java
@@ -81,6 +81,8 @@ public class TransferenciaUseCase {
         
         return new TransferenciaResponse(
             contaOrigem.getNumeroConta(), 
+            contaDestino.getNumeroConta(),
+            valorTransferencia.doubleValue(),
             contaOrigem.getSaldo().doubleValue(), 
             transferencia.getDataHora().toString());
     }

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/domain/repository/MovimentacaoQueryRepository.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/domain/repository/MovimentacaoQueryRepository.java
@@ -16,4 +16,8 @@ public interface MovimentacaoQueryRepository extends JpaRepository<MovimentacaoQ
 
     List<MovimentacaoQuery> findByContaOrigemNumeroOrContaDestinoNumero(String contaOrigemNumero, String contaDestinoNumero);
 
+    List<MovimentacaoQuery> findByContaOrigemNumeroOrContaDestinoNumeroOrderByDataHoraAsc(
+        String contaOrigemNumero,
+        String contaDestinoNumero);
+
 }

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/infrastructure/cache/redis/listener/SyncListener.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/infrastructure/cache/redis/listener/SyncListener.java
@@ -5,7 +5,6 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.ufpr.bantads.conta.application.dto.event.MovimentacaoEvent;
-import com.ufpr.bantads.conta.infrastructure.cache.redis.model.ContaCache;
 import com.ufpr.bantads.conta.infrastructure.cache.redis.repository.ContaCacheRedisRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -27,7 +26,7 @@ public class SyncListener {
             return;
         }
 
-        cacheRedisRepository.deleteById(ContaCache.idForNumeroConta(numeroConta));
+        cacheRedisRepository.deleteById(numeroConta);
     }
 
 }

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/infrastructure/cache/redis/listener/SyncListener.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/infrastructure/cache/redis/listener/SyncListener.java
@@ -1,0 +1,33 @@
+package com.ufpr.bantads.conta.infrastructure.cache.redis.listener;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.ufpr.bantads.conta.application.dto.event.MovimentacaoEvent;
+import com.ufpr.bantads.conta.infrastructure.cache.redis.model.ContaCache;
+import com.ufpr.bantads.conta.infrastructure.cache.redis.repository.ContaCacheRedisRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SyncListener {
+
+    private final ContaCacheRedisRepository cacheRedisRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void evictOldCache(MovimentacaoEvent event) {
+        evictIfPresent(event.getNumeroContaOrigem());
+        evictIfPresent(event.getNumeroContaDestino());
+    }
+
+    private void evictIfPresent(String numeroConta) {
+        if (numeroConta == null || numeroConta.isBlank()) {
+            return;
+        }
+
+        cacheRedisRepository.deleteById(ContaCache.idForNumeroConta(numeroConta));
+    }
+
+}

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/infrastructure/cache/redis/model/ContaCache.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/infrastructure/cache/redis/model/ContaCache.java
@@ -20,14 +20,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ContaCache {
 
-    public static String idForNumeroConta(String numeroConta) {
-        return numeroConta;
-    }
-
     @Id
-    private String id;
-
-    @Indexed
     private String numeroConta;
 
     @Indexed

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/infrastructure/cache/redis/model/ContaCache.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/infrastructure/cache/redis/model/ContaCache.java
@@ -1,0 +1,47 @@
+package com.ufpr.bantads.conta.infrastructure.cache.redis.model;
+
+import java.math.BigDecimal;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@RedisHash("ms-conta:conta")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContaCache {
+
+    public static String idForNumeroConta(String numeroConta) {
+        return numeroConta;
+    }
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String numeroConta;
+
+    @Indexed
+    private String clienteCpf;
+
+    @Indexed
+    private String eventId;
+
+    private BigDecimal saldo;
+
+    /**
+     * TTL em segundos.
+     * Aqui o cache expira automaticamente depois de 60 segundos.
+     */
+    @Builder.Default
+    private Long expiration = 60L;
+}

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/infrastructure/cache/redis/repository/ContaCacheRedisRepository.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/infrastructure/cache/redis/repository/ContaCacheRedisRepository.java
@@ -1,0 +1,17 @@
+package com.ufpr.bantads.conta.infrastructure.cache.redis.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.ufpr.bantads.conta.infrastructure.cache.redis.model.ContaCache;
+
+public interface ContaCacheRedisRepository extends CrudRepository<ContaCache, String> {
+
+    Optional<ContaCache> findByNumeroConta(String numero);
+
+    Optional<ContaCache> findByClienteCpf(String clienteCpf);
+
+    Optional<ContaCache> eventId(String clienteCpf);
+
+}

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/infrastructure/config/RedisRepositoriesConfig.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/infrastructure/config/RedisRepositoriesConfig.java
@@ -1,0 +1,11 @@
+package com.ufpr.bantads.conta.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories(
+    basePackages = "com.ufpr.bantads.conta.infrastructure.cache.redis.repository"
+)
+public class RedisRepositoriesConfig {
+}

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/presentation/rest/ContaController.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/presentation/rest/ContaController.java
@@ -40,8 +40,6 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class ContaController {
-    private static final long READ_MODEL_DELAY_MILLIS = 500;
-
     private final GetSaldoUseCase getSaldoUseCase;
     private final GetExtratoUseCase getExtratoUseCase;
     private final DepositarUseCase depositarUseCase;
@@ -111,7 +109,6 @@ public class ContaController {
         }
 
         DepositoSaqueResponse depositoResponse = depositarUseCase.execute(conta, request.valor());
-        aguardarAtualizacaoLeitura();
         return ResponseEntity.ok(depositoResponse);
     }
 
@@ -124,7 +121,6 @@ public class ContaController {
         }
 
         DepositoSaqueResponse depositoResponse = sacarUseCase.execute(conta, request.valor());
-        aguardarAtualizacaoLeitura();
         return ResponseEntity.ok(depositoResponse);
     }
 
@@ -138,15 +134,6 @@ public class ContaController {
 
         TransferenciaResponse transferenciaResponse = transferenciaUseCase.execute(conta, request.destino(),
                 request.valor());
-        aguardarAtualizacaoLeitura();
         return ResponseEntity.ok(transferenciaResponse);
-    }
-
-    private void aguardarAtualizacaoLeitura() {
-        try {
-            Thread.sleep(READ_MODEL_DELAY_MILLIS);
-        } catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-        }
     }
 }

--- a/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/presentation/rest/ContaController.java
+++ b/backend/ms-conta/src/main/java/com/ufpr/bantads/conta/presentation/rest/ContaController.java
@@ -40,6 +40,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class ContaController {
+    private static final long READ_MODEL_DELAY_MILLIS = 500;
 
     private final GetSaldoUseCase getSaldoUseCase;
     private final GetExtratoUseCase getExtratoUseCase;
@@ -110,6 +111,7 @@ public class ContaController {
         }
 
         DepositoSaqueResponse depositoResponse = depositarUseCase.execute(conta, request.valor());
+        aguardarAtualizacaoLeitura();
         return ResponseEntity.ok(depositoResponse);
     }
 
@@ -122,6 +124,7 @@ public class ContaController {
         }
 
         DepositoSaqueResponse depositoResponse = sacarUseCase.execute(conta, request.valor());
+        aguardarAtualizacaoLeitura();
         return ResponseEntity.ok(depositoResponse);
     }
 
@@ -135,6 +138,15 @@ public class ContaController {
 
         TransferenciaResponse transferenciaResponse = transferenciaUseCase.execute(conta, request.destino(),
                 request.valor());
+        aguardarAtualizacaoLeitura();
         return ResponseEntity.ok(transferenciaResponse);
+    }
+
+    private void aguardarAtualizacaoLeitura() {
+        try {
+            Thread.sleep(READ_MODEL_DELAY_MILLIS);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/backend/ms-conta/src/main/resources/application.yml
+++ b/backend/ms-conta/src/main/resources/application.yml
@@ -20,6 +20,12 @@ spring:
     port: ${RABBITMQ_PORT:5672}
     username: ${RABBITMQ_DEFAULT_USER:guest}
     password: ${RABBITMQ_DEFAULT_PASS:guest}
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      database: ${REDIS_DATABASE_CONTA:1}
+      timeout: 2s
 
 cqrs:
   rabbitmq:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,12 +132,17 @@ services:
       POSTGRES_HOST: postgres-db
       DB_HOST: postgres-db
       RABBITMQ_HOST: rabbitmq
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_DATABASE_CONTA: 1
     ports:
       - "8083:8083"
     depends_on:
       postgres-db:
         condition: service_healthy
       rabbitmq:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     networks:
       - bantads-network


### PR DESCRIPTION
MS-Conta usa redis para salvar o saldo da conta durante a sincronização do CQRS, depois de atualizado o banco de leitura o cache é deletado.

<img width="633" height="111" alt="image" src="https://github.com/user-attachments/assets/1c3d3b68-12f0-4ccc-820e-3be665ff98fe" />
